### PR TITLE
Fixed sys_prep.sh hack to 'auto-log' gpadmin user

### DIFF
--- a/Vagrant/sys_prep.sh
+++ b/Vagrant/sys_prep.sh
@@ -61,12 +61,6 @@ echo "Upgrading the semaphore values"
 echo "kernel.sem = 250 512000 100 2048" >> /etc/sysctl.conf
 /sbin/sysctl -p
 
-echo "Updating the vagrant user bashrc to auto login to gpadmin"
-{
-    echo "sudo su - gpadmin"
-    echo "exit"
-} >> /home/vagrant/.bashrc
-
 echo "Cleaning up the tmp directory"
 rm -rf /tmp/piv-go-gpdb
 


### PR DESCRIPTION
Removed the lines in sys_prep.sh that were appending a `sudo su - gpadmin` to `vagrant` user's `~/.bashrc`.

This hack was breaking the vagrant halt functionality and it's a dirty hack to save you 2 seconds of typing.

Signed-off-by: Aitor Cedres <acedres@pivotal.io>